### PR TITLE
update runtime to GNOME 46

### DIFF
--- a/io.github.swanux.hbud.yml
+++ b/io.github.swanux.hbud.yml
@@ -1,6 +1,6 @@
 app-id: io.github.swanux.hbud
 runtime: org.gnome.Platform
-runtime-version: '43'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: hbud
 sdk-extensions:


### PR DESCRIPTION
lets see if it builds. Currently uses an EOL runtime.